### PR TITLE
Joomla 3.8 compatibility 

### DIFF
--- a/src/Joomlatools/Joomla/Application.php
+++ b/src/Joomlatools/Joomla/Application.php
@@ -454,7 +454,7 @@ class Application extends JApplicationCli
      */
     protected function _setupLogging($loglevel)
     {
-        require_once JPATH_LIBRARIES . '/joomla/log/log.php';
+        require_once JPATH_LIBRARIES . '/src/Log/Log.php';
 
         if ($loglevel == OutputInterface::VERBOSITY_NORMAL) {
             return;

--- a/src/Joomlatools/Joomla/Application.php
+++ b/src/Joomlatools/Joomla/Application.php
@@ -454,7 +454,12 @@ class Application extends JApplicationCli
      */
     protected function _setupLogging($loglevel)
     {
-        require_once JPATH_LIBRARIES . '/src/Log/Log.php';
+        // Backwards compatibility
+        if (file_exists(JPATH_LIBRARIES . '/src/Log/Log.php')) {
+          require_once JPATH_LIBRARIES . '/src/Log/Log.php';
+        } else {
+          require_once JPATH_LIBRARIES . '/joomla/log/log.php';
+        }
 
         if ($loglevel == OutputInterface::VERBOSITY_NORMAL) {
             return;

--- a/src/Joomlatools/Joomla/Bootstrapper.php
+++ b/src/Joomlatools/Joomla/Bootstrapper.php
@@ -157,7 +157,7 @@ class Bootstrapper
         $_SERVER['HTTP_USER_AGENT'] = 'Composer';
 
         define('DS', DIRECTORY_SEPARATOR);
-        define('JDEBUG', $this->_application->getCfg('debug'));
+        define('JDEBUG', '0');
 
         $base = realpath('.');
 

--- a/src/Joomlatools/Joomla/Bootstrapper.php
+++ b/src/Joomlatools/Joomla/Bootstrapper.php
@@ -157,6 +157,7 @@ class Bootstrapper
         $_SERVER['HTTP_USER_AGENT'] = 'Composer';
 
         define('DS', DIRECTORY_SEPARATOR);
+        define('JDEBUG', $this->_application->getCfg('debug'));
 
         $base = realpath('.');
 

--- a/src/Joomlatools/Joomla/Bootstrapper.php
+++ b/src/Joomlatools/Joomla/Bootstrapper.php
@@ -188,7 +188,6 @@ class Bootstrapper
             define('JPATH_BASE', $base);
 
             require_once JPATH_BASE . '/includes/defines.php';
-            require_once JPATH_BASE . '/includes/framework.php';
         }
 
         require_once JPATH_LIBRARIES . '/import.php';


### PR DESCRIPTION
The changes make the library work with Joomla 3.8 while keeping backwards compatibility for older versions.