### PR TITLE
Get tag for language type fixed

### DIFF
--- a/src/Joomlatools/Joomla/Util.php
+++ b/src/Joomlatools/Joomla/Util.php
@@ -202,7 +202,7 @@ class Util
                 }
                 break;
             case 'language':
-                $element = $xml->get('tag');
+                $element = (string) $xml->tag;
                 break;
             case 'template':
                 $name    = preg_replace('/[^A-Z0-9_ \.-]/i', '', $xml->name);


### PR DESCRIPTION
First of all I'd like to thank you all for the great Composer extension you created here. After investing a lot of time in automatizing our setup, this extension solved most of the problems we were facing. :+1: 

Our application is multi language and while trying to install Joomla language packages the process failed.

After some debugging I was able to fix the issue with the following change. Since then the installation works without any problems.