### PR TITLE
Reset the phar wrapper

### DIFF
--- a/src/Joomlatools/Joomla/Bootstrapper.php
+++ b/src/Joomlatools/Joomla/Bootstrapper.php
@@ -197,7 +197,7 @@ class Bootstrapper
 
         require_once JPATH_LIBRARIES . '/cms.php';
 
-        stream_wrapper_restore('Phar');
+        stream_wrapper_restore('phar');
 
         $this->_bootstrapped = true;
 

--- a/src/Joomlatools/Joomla/Bootstrapper.php
+++ b/src/Joomlatools/Joomla/Bootstrapper.php
@@ -194,16 +194,10 @@ class Bootstrapper
         }
 
         // cache the current phar stream wrapper
-        $wrappers = stream_get_wrappers();
 
         require_once JPATH_LIBRARIES . '/cms.php';
 
-        if (in_array('phar', stream_get_wrappers()) && isset($wrappers['phar']))
-        {
-            stream_wrapper_unregister('phar');
-            stream_wrapper_register('phar', $wrappers['phar']);
-        }
-
+        stream_wrapper_restore('Phar');
 
         $this->_bootstrapped = true;
 

--- a/src/Joomlatools/Joomla/Bootstrapper.php
+++ b/src/Joomlatools/Joomla/Bootstrapper.php
@@ -193,8 +193,20 @@ class Bootstrapper
             require_once JPATH_BASE . '/includes/framework.php';
         }
 
+        // cache the current phar stream wrapper
+        $wrappers = stream_get_wrappers();
+
         require_once JPATH_LIBRARIES . '/cms.php';
 
+        if (in_array('phar', stream_get_wrappers()) && isset($wrappers['phar']))
+        {
+            stream_wrapper_unregister('phar');
+            stream_wrapper_register('phar', $wrappers['phar']);
+        }
+
+
         $this->_bootstrapped = true;
+
+
     }
 }


### PR DESCRIPTION
As of Joomla! 3.9.4 the phar stream wrapper is re-registered using the  typo3/phar-stream-wrapper.

After that, using the joomlatools/composer would fail with an unexpected file extension error. 

This PR:
1. simply resets the phar stream wrapper to the previously set wrapper. 

You may want to do a deeper dive into the underlying security concern, but this certainly fixed the immediate issue. 